### PR TITLE
Fix markdown formatting in CONTRIBUTORS file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,2 @@
-Matthew Hall
-Kevin Balz
+* Matthew Hall
+* Kevin Balz


### PR DESCRIPTION
The old version globs all names into a single paragraph when rendered to markdown.
