### PR TITLE
WIP Add get_tile_rectangle_by_id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,31 @@ impl Map {
         }
         maximum_ts
     }
+
+    /// Computes the rectangle on the image where the sprite is stored for the given tile ID.
+    /// If the ID is not found in any tileset, or if there is no image associated with the tileset, `None` is returned.
+    /// On success, returns `Some(x, y, w, h)`, where `(x, y)` is the coordinates of the top-left corner, and `(w, h)` are the width and height of the rectangle
+    pub fn get_tile_rectangle_by_id(&self, id: u32) -> Option<(u32, u32, u32, u32)> {
+        let tileset = self.get_tileset_by_gid(id)?;
+        let img = tileset.images.get(0)?; // we suppose there is only 1 image per tileset
+
+        let id = id - 1;
+        let columns =
+            (img.width as u32 - 2 * tileset.margin) / (tileset.spacing + tileset.tile_width);
+
+        // coordinates in tiles
+        let x = id % columns;
+        let y = id.div_euclid(columns);
+
+        // coordinates in pixels
+        let x = tileset.margin + (tileset.tile_width + tileset.spacing) * x;
+        let y = tileset.margin + (tileset.tile_height + tileset.spacing) * y;
+
+        let w = tileset.tile_width;
+        let h = tileset.tile_height;
+
+        Some((x, y, w, h))
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]


### PR DESCRIPTION
This is still a work in progress

Helper function for #35

This method return the rectangle where the sprite is located on the image texture.
I tested the math with a few tilesheets (with and without margin/spacings). Seems fine, but I'm not 100% sure!

The rendering code looks like this(using tetra):
```
for layer in map.layers.iter() {
    let tile_width = map.tile_width as f32;
    let tile_height = map.tile_height as f32;
    let texture = ...

    for (j, row) in layer.tiles.iter().enumerate() {
        for (i, tile) in row.iter().enumerate() {
            if tile.gid == 0 {
                continue;
            }
            let p = Vec2::new(i as f32 * tile_width, j as f32 * tile_height);
            let rect = self.map.get_tile_rect_by_id(tile.gid);

            graphics::draw(ctx, texture, DrawParams::default().position(p).clip(rect));
        }
    }
}

```