### PR TITLE
Added support for Object templates

### DIFF
--- a/assets/tiled_object_template.tmx
+++ b/assets/tiled_object_template.tmx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.4" tiledversion="1.4.2" orientation="orthogonal" renderorder="right-down" width="3" height="3" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="3">
+ <tileset firstgid="1" source="tilesheet.tsx"/>
+ <layer id="1" name="Tile Layer 1" width="3" height="3">
+  <data encoding="csv">
+6,7,8,
+20,21,22,
+34,35,36
+</data>
+ </layer>
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="1" template="tiled_object_template.tx" x="32" y="32">
+   <properties>
+   </properties>
+  </object>
+  <object id="2" gid="45" x="0" y="32" width="32" height="32"/>
+ </objectgroup>
+</map>

--- a/assets/tiled_object_template.tx
+++ b/assets/tiled_object_template.tx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<template>
+ <tileset firstgid="1" source="tilesheet.tsx"/>
+ <object gid="45" width="32" height="32">
+  <properties>
+   <property name="property" type="int" value="1"/>
+  </properties>
+ </object>
+</template>

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -148,3 +148,27 @@ fn test_flipped_gid() {
     }
     
 }
+
+#[test]
+fn test_object_template_property() {
+    let r = read_from_file_with_path(&Path::new("assets/tiled_object_template.tmx")).unwrap();
+    let object = &r.object_groups[0].objects[0]; // The templated object
+    let object_nt = &r.object_groups[0].objects[1]; // The non-templated object
+
+    assert_eq!(object_nt.template, None);
+
+    let template_object = object.template.as_ref().unwrap().object.as_ref().unwrap();
+    assert_eq!(template_object.gid, 45);
+    assert_eq!(template_object.width, 32.0);
+    assert_eq!(template_object.height, 32.0);
+    assert_eq!(
+        template_object.properties.get("property").unwrap().clone(),
+        PropertyValue::IntValue(1)
+    );
+
+    let tileset = object.template.as_ref().unwrap().tileset.as_ref().unwrap();
+    assert_eq!(
+        tileset.properties.get("tileset property").unwrap().clone(),
+        PropertyValue::StringValue("tsp".to_string())
+    );
+}


### PR DESCRIPTION
This adds a `template` property to Objects, which is parsed from an
external template file, if its specified using the "template" attribute.

I'm still a little new to Rust, so let me know if the code isn't Rust-y enough.

I had to pass the path around quite a bit, since now Objects need to know the map_path (to load the template, if needed), and objects exist in many places.

I also marked the `x` and `y` properties of objects as optional, since they are listed that way on the docs and templates don't have them.