### PR TITLE
Add layer id parsing

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -75,7 +75,7 @@ impl Layer {
             ],
             required: [
                 ("name", name, |v| Some(v)),
-                ("id", id, |v:String| v.parse::<u32>().ok()),
+                ("id", id, |v:String| v.parse().ok()),
             ],
             TiledError::MalformedAttributes("layer must have a name".to_string())
         );

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -54,6 +54,7 @@ pub struct Layer {
     pub tiles: LayerData,
     pub properties: Properties,
     pub layer_index: u32,
+    pub id: u32,
 }
 
 impl Layer {
@@ -64,7 +65,7 @@ impl Layer {
         layer_index: u32,
         infinite: bool,
     ) -> Result<Layer, TiledError> {
-        let ((o, v, ox, oy), n) = get_attrs!(
+        let ((o, v, ox, oy), (n, id)) = get_attrs!(
             attrs,
             optionals: [
                 ("opacity", opacity, |v:String| v.parse().ok()),
@@ -74,6 +75,7 @@ impl Layer {
             ],
             required: [
                 ("name", name, |v| Some(v)),
+                ("id", id, |v:String| v.parse::<u32>().ok()),
             ],
             TiledError::MalformedAttributes("layer must have a name".to_string())
         );
@@ -103,6 +105,7 @@ impl Layer {
             tiles: tiles,
             properties: properties,
             layer_index,
+            id,
         })
     }
 }

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -54,6 +54,8 @@ pub struct Layer {
     pub tiles: LayerData,
     pub properties: Properties,
     pub layer_index: u32,
+    /// The ID of the layer, as shown in the editor.
+    /// Layer ID stays the same even if layers are reordered or modified in the editor.
     pub id: u32,
 }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -20,6 +20,7 @@ pub struct ObjectGroup {
      */
     pub layer_index: Option<u32>,
     pub properties: Properties,
+    pub id: u32,
 }
 
 impl ObjectGroup {
@@ -28,7 +29,7 @@ impl ObjectGroup {
         attrs: Vec<OwnedAttribute>,
         layer_index: Option<u32>,
     ) -> Result<ObjectGroup, TiledError> {
-        let ((o, v, c, n), ()) = get_attrs!(
+        let ((o, v, c, n), id) = get_attrs!(
             attrs,
             optionals: [
                 ("opacity", opacity, |v:String| v.parse().ok()),
@@ -36,7 +37,9 @@ impl ObjectGroup {
                 ("color", colour, |v:String| v.parse().ok()),
                 ("name", name, |v:String| v.into()),
             ],
-            required: [],
+            required: [
+                ("id", id, |v:String| v.parse::<u32>().ok()),
+            ],
             TiledError::MalformedAttributes("object groups must have a name".to_string())
         );
         let mut objects = Vec::new();
@@ -59,6 +62,7 @@ impl ObjectGroup {
             colour: c,
             layer_index,
             properties,
+            id,
         })
     }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -38,7 +38,7 @@ impl ObjectGroup {
                 ("name", name, |v:String| v.into()),
             ],
             required: [
-                ("id", id, |v:String| v.parse::<u32>().ok()),
+                ("id", id, |v:String| v.parse().ok()),
             ],
             TiledError::MalformedAttributes("object groups must have a name".to_string())
         );

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -20,6 +20,8 @@ pub struct ObjectGroup {
      */
     pub layer_index: Option<u32>,
     pub properties: Properties,
+    /// The ID of the layer, as shown in the editor.
+    /// Layer ID stays the same even if layers are reordered or modified in the editor.
     pub id: u32,
 }
 


### PR DESCRIPTION
Adds support for parsing the layer "id" attribute.
Unlike layer index, the id of a layer always stays the same, even if the order is changed or other layers are added/deleted.
(eg. this can be useful for identifying a layer in an int property on an object)