### PR TITLE
Make layer ids optional and make tile layer name optional (like object layers)

### DIFF
--- a/src/layers.rs
+++ b/src/layers.rs
@@ -127,6 +127,9 @@ pub struct ImageLayer {
     pub image: Option<Image>,
     pub properties: Properties,
     pub layer_index: u32,
+    /// The ID of the layer, as shown in the editor.
+    /// Layer ID stays the same even if layers are reordered or modified in the editor.
+    pub id: u32,
 }
 
 impl ImageLayer {
@@ -135,18 +138,20 @@ impl ImageLayer {
         attrs: Vec<OwnedAttribute>,
         layer_index: u32,
     ) -> Result<ImageLayer, TiledError> {
-        let ((o, v, ox, oy), n) = get_attrs!(
+        let ((o, v, ox, oy, n, id), ()) = get_attrs!(
             attrs,
             optionals: [
                 ("opacity", opacity, |v:String| v.parse().ok()),
                 ("visible", visible, |v:String| v.parse().ok().map(|x:i32| x == 1)),
                 ("offsetx", offset_x, |v:String| v.parse().ok()),
                 ("offsety", offset_y, |v:String| v.parse().ok()),
-            ],
-            required: [
                 ("name", name, |v| Some(v)),
+                ("id", id, |v:String| v.parse().ok()),
             ],
-            TiledError::MalformedAttributes("layer must have a name".to_string()));
+            required: [],
+            // this error should never happen since there are no required attrs
+            TiledError::MalformedAttributes("image layer parsing error".to_string())
+        );
         let mut properties = HashMap::new();
         let mut image: Option<Image> = None;
         parse_tag!(parser, "imagelayer", {
@@ -160,7 +165,7 @@ impl ImageLayer {
             },
         });
         Ok(ImageLayer {
-            name: n,
+            name: n.unwrap_or(String::new()),
             opacity: o.unwrap_or(1.0),
             visible: v.unwrap_or(true),
             offset_x: ox.unwrap_or(0.0),
@@ -168,6 +173,7 @@ impl ImageLayer {
             image,
             properties,
             layer_index,
+            id: id.unwrap_or(0),
         })
     }
 }

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -67,19 +67,19 @@ impl Layer {
         layer_index: u32,
         infinite: bool,
     ) -> Result<Layer, TiledError> {
-        let ((o, v, ox, oy), (n, id)) = get_attrs!(
+        let ((o, v, ox, oy, n, id), ()) = get_attrs!(
             attrs,
             optionals: [
                 ("opacity", opacity, |v:String| v.parse().ok()),
                 ("visible", visible, |v:String| v.parse().ok().map(|x:i32| x == 1)),
                 ("offsetx", offset_x, |v:String| v.parse().ok()),
                 ("offsety", offset_y, |v:String| v.parse().ok()),
-            ],
-            required: [
                 ("name", name, |v| Some(v)),
                 ("id", id, |v:String| v.parse().ok()),
             ],
-            TiledError::MalformedAttributes("layer must have a name".to_string())
+            required: [],
+            // this error should never happen since there are no required attrs
+            TiledError::MalformedAttributes("layer parsing error".to_string())
         );
         let mut tiles: LayerData = LayerData::Finite(Default::default());
         let mut properties = HashMap::new();
@@ -99,7 +99,7 @@ impl Layer {
         });
 
         Ok(Layer {
-            name: n,
+            name: n.unwrap_or(String::new()),
             opacity: o.unwrap_or(1.0),
             visible: v.unwrap_or(true),
             offset_x: ox.unwrap_or(0.0),
@@ -107,7 +107,7 @@ impl Layer {
             tiles: tiles,
             properties: properties,
             layer_index,
-            id,
+            id: id.unwrap_or(0),
         })
     }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -31,18 +31,18 @@ impl ObjectGroup {
         attrs: Vec<OwnedAttribute>,
         layer_index: Option<u32>,
     ) -> Result<ObjectGroup, TiledError> {
-        let ((o, v, c, n), id) = get_attrs!(
+        let ((o, v, c, n, id), ()) = get_attrs!(
             attrs,
             optionals: [
                 ("opacity", opacity, |v:String| v.parse().ok()),
                 ("visible", visible, |v:String| v.parse().ok().map(|x:i32| x == 1)),
                 ("color", colour, |v:String| v.parse().ok()),
-                ("name", name, |v:String| v.into()),
-            ],
-            required: [
+                ("name", name, |v:String| Some(v)),
                 ("id", id, |v:String| v.parse().ok()),
             ],
-            TiledError::MalformedAttributes("object groups must have a name".to_string())
+            required: [],
+            // this error should never happen since there are no required attrs
+            TiledError::MalformedAttributes("object group parsing error".to_string())
         );
         let mut objects = Vec::new();
         let mut properties = HashMap::new();
@@ -64,7 +64,7 @@ impl ObjectGroup {
             colour: c,
             layer_index,
             properties,
-            id,
+            id: id.unwrap_or(0),
         })
     }
 }


### PR DESCRIPTION
Follow-up for #111

Layer id defaults to 0 if missing, which is normally unused.
Tile layer name defaults to an empty String if missing, same as object layers.