### PR TITLE
Better errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ pub enum ParseTileError {
 
 /// Errors which occured when parsing the file
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TiledError {
     /// A attribute was missing, had the wrong type of wasn't formated
     /// correctly.

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,9 @@ pub enum TiledError {
     /// 
     /// [`PropertyValue`]: crate::PropertyValue
     InvalidPropertyValue,
+    /// Found an unknown property value type while parsing a [`PropertyValue`].
+    /// 
+    /// [`PropertyValue`]: crate::PropertyValue
     UnknownPropertyType{name: String},
 }
 
@@ -79,7 +82,6 @@ impl fmt::Display for TiledError {
     }
 }
 
-// This is a skeleton implementation, which should probably be extended in the future.
 impl std::error::Error for TiledError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,9 +13,8 @@ pub enum TiledError {
     /// A attribute was missing, had the wrong type of wasn't formated
     /// correctly.
     MalformedAttributes(String),
-    /// An error occured when decompressing using the
-    /// [flate2](https://github.com/alexcrichton/flate2-rs) crate.
-    DecompressingError(std::io::Error),
+    /// An error occured when using I/O functionality (e.g. decompression or file reading)
+    IoError(std::io::Error),
     Base64DecodingError(base64::DecodeError),
     XmlDecodingError(xml::reader::Error),
     PrematureEnd(String),
@@ -44,7 +43,7 @@ impl fmt::Display for TiledError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             TiledError::MalformedAttributes(s) => write!(fmt, "{}", s),
-            TiledError::DecompressingError(e) => write!(fmt, "{}", e),
+            TiledError::IoError(e) => write!(fmt, "{}", e),
             TiledError::Base64DecodingError(e) => write!(fmt, "{}", e),
             TiledError::XmlDecodingError(e) => write!(fmt, "{}", e),
             TiledError::PrematureEnd(e) => write!(fmt, "{}", e),
@@ -84,7 +83,7 @@ impl fmt::Display for TiledError {
 impl std::error::Error for TiledError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            TiledError::DecompressingError(e) => Some(e as &dyn std::error::Error),
+            TiledError::IoError(e) => Some(e as &dyn std::error::Error),
             TiledError::Base64DecodingError(e) => Some(e as &dyn std::error::Error),
             TiledError::XmlDecodingError(e) => Some(e as &dyn std::error::Error),
             TiledError::CouldNotOpenFile { err, .. } => Some(err as &dyn std::error::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,6 @@ pub enum TiledError {
     /// [`PropertyValue`]: crate::PropertyValue
     InvalidPropertyValue,
     UnknownPropertyType{name: String},
-    Other(String),
 }
 
 impl fmt::Display for TiledError {
@@ -72,7 +71,6 @@ impl fmt::Display for TiledError {
                 )
             }
             TiledError::InvalidTileFound => write!(fmt, "Invalid tile found in map being parsed"),
-            TiledError::Other(s) => write!(fmt, "{}", s),
             TiledError::InvalidEncodingFormat { encoding, compression } => 
                 write!(
                     fmt,

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,11 @@ pub enum TiledError {
         encoding: Option<String>,
         compression: Option<String>,
     },
+    /// There was an error parsing the value of a [`PropertyValue`].
+    /// 
+    /// [`PropertyValue`]: crate::PropertyValue
+    InvalidPropertyValue,
+    UnknownPropertyType{name: String},
     Other(String),
 }
 
@@ -75,6 +80,9 @@ impl fmt::Display for TiledError {
                     encoding.as_deref().unwrap_or("no"),
                     compression.as_deref().unwrap_or("no")
                 ),
+            TiledError::InvalidPropertyValue => write!(fmt, "Found invalid property value"),
+            TiledError::UnknownPropertyType { name } =>
+                write!(fmt, "Found unknown property value type '{}'", name),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,8 +7,9 @@ pub enum TiledError {
     /// A attribute was missing, had the wrong type of wasn't formated
     /// correctly.
     MalformedAttributes(String),
-    /// An error occured when using I/O functionality (e.g. decompression or file reading)
-    IoError(std::io::Error),
+    /// An error occured when decompressing using the
+    /// [flate2](https://github.com/alexcrichton/flate2-rs) crate.
+    DecompressingError(std::io::Error),
     Base64DecodingError(base64::DecodeError),
     XmlDecodingError(xml::reader::Error),
     PrematureEnd(String),
@@ -44,7 +45,7 @@ impl fmt::Display for TiledError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             TiledError::MalformedAttributes(s) => write!(fmt, "{}", s),
-            TiledError::IoError(e) => write!(fmt, "{}", e),
+            TiledError::DecompressingError(e) => write!(fmt, "{}", e),
             TiledError::Base64DecodingError(e) => write!(fmt, "{}", e),
             TiledError::XmlDecodingError(e) => write!(fmt, "{}", e),
             TiledError::PrematureEnd(e) => write!(fmt, "{}", e),
@@ -85,7 +86,7 @@ impl fmt::Display for TiledError {
 impl std::error::Error for TiledError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            TiledError::IoError(e) => Some(e as &dyn std::error::Error),
+            TiledError::DecompressingError(e) => Some(e as &dyn std::error::Error),
             TiledError::Base64DecodingError(e) => Some(e as &dyn std::error::Error),
             TiledError::XmlDecodingError(e) => Some(e as &dyn std::error::Error),
             TiledError::CouldNotOpenFile { err, .. } => Some(err as &dyn std::error::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,11 @@ pub enum TiledError {
     },
     /// There was an invalid tile in the map parsed.
     InvalidTileFound,
+    /// Unknown encoding or compression format or invalid combination of both (for tile layers)
+    InvalidEncodingFormat {
+        encoding: Option<String>,
+        compression: Option<String>,
+    },
     Other(String),
 }
 
@@ -64,6 +69,13 @@ impl fmt::Display for TiledError {
             }
             TiledError::InvalidTileFound => write!(fmt, "Invalid tile found in map being parsed"),
             TiledError::Other(s) => write!(fmt, "{}", s),
+            TiledError::InvalidEncodingFormat { encoding, compression } => 
+                write!(
+                    fmt,
+                    "Unknown encoding or compression format or invalid combination of both (for tile layers): {} encoding with {} compression",
+                    encoding.as_deref().unwrap_or("no"),
+                    compression.as_deref().unwrap_or("no")
+                ),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,7 +34,7 @@ pub enum TiledError {
     /// There was an error parsing the value of a [`PropertyValue`].
     /// 
     /// [`PropertyValue`]: crate::PropertyValue
-    InvalidPropertyValue,
+    InvalidPropertyValue{description: String},
     /// Found an unknown property value type while parsing a [`PropertyValue`].
     /// 
     /// [`PropertyValue`]: crate::PropertyValue
@@ -69,6 +69,11 @@ impl fmt::Display for TiledError {
                 )
             }
             TiledError::InvalidTileFound => write!(fmt, "Invalid tile found in map being parsed"),
+            TiledError::InvalidEncodingFormat { encoding: None, compression: None } => 
+                write!(
+                    fmt,
+                    "Deprecated combination of encoding and compression"
+                ),
             TiledError::InvalidEncodingFormat { encoding, compression } => 
                 write!(
                     fmt,
@@ -76,9 +81,10 @@ impl fmt::Display for TiledError {
                     encoding.as_deref().unwrap_or("no"),
                     compression.as_deref().unwrap_or("no")
                 ),
-            TiledError::InvalidPropertyValue => write!(fmt, "Found invalid property value"),
+            TiledError::InvalidPropertyValue{description} =>
+                write!(fmt, "Invalid property value: {}", description),
             TiledError::UnknownPropertyType { name } =>
-                write!(fmt, "Found unknown property value type '{}'", name),
+                write!(fmt, "Unknown property value type '{}'", name),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,5 @@
 use std::{fmt, path::PathBuf};
 
-#[derive(Debug, Copy, Clone)]
-pub enum ParseTileError {
-    ColorError,
-    OrientationError,
-}
-
 /// Errors which occured when parsing the file
 #[derive(Debug)]
 #[non_exhaustive]

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -80,11 +80,11 @@ fn parse_base64(parser: &mut impl Iterator<Item = XmlEventResult>) -> Result<Vec
 fn decode_zlib(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
     use libflate::zlib::Decoder;
     let mut zd =
-        Decoder::new(BufReader::new(&data[..])).map_err(|e| TiledError::DecompressingError(e))?;
+        Decoder::new(BufReader::new(&data[..])).map_err(|e| TiledError::IoError(e))?;
     let mut data = Vec::new();
     match zd.read_to_end(&mut data) {
         Ok(_v) => {}
-        Err(e) => return Err(TiledError::DecompressingError(e)),
+        Err(e) => return Err(TiledError::IoError(e)),
     }
     Ok(data)
 }
@@ -92,11 +92,11 @@ fn decode_zlib(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
 fn decode_gzip(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
     use libflate::gzip::Decoder;
     let mut zd =
-        Decoder::new(BufReader::new(&data[..])).map_err(|e| TiledError::DecompressingError(e))?;
+        Decoder::new(BufReader::new(&data[..])).map_err(|e| TiledError::IoError(e))?;
 
     let mut data = Vec::new();
     zd.read_to_end(&mut data)
-        .map_err(|e| TiledError::DecompressingError(e))?;
+        .map_err(|e| TiledError::IoError(e))?;
     Ok(data)
 }
 
@@ -105,11 +105,11 @@ fn decode_zstd(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
     use zstd::stream::read::Decoder;
 
     let buff = Cursor::new(&data);
-    let mut zd = Decoder::with_buffer(buff).map_err(|e| TiledError::DecompressingError(e))?;
+    let mut zd = Decoder::with_buffer(buff).map_err(|e| TiledError::IoError(e))?;
 
     let mut data = Vec::new();
     zd.read_to_end(&mut data)
-        .map_err(|e| TiledError::DecompressingError(e))?;
+        .map_err(|e| TiledError::IoError(e))?;
     Ok(data)
 }
 

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -11,12 +11,6 @@ pub(crate) fn parse_data_line(
     tilesets: &[MapTilesetGid],
 ) -> Result<Vec<Option<LayerTileData>>, TiledError> {
     match (encoding.as_deref(), compression.as_deref()) {
-        (None, None) => {
-            return Err(TiledError::InvalidEncodingFormat {
-                encoding,
-                compression,
-            })
-        }
         (Some("base64"), None) => {
             return parse_base64(parser).map(|v| convert_to_tiles(&v, tilesets))
         }

--- a/src/layers/tile/util.rs
+++ b/src/layers/tile/util.rs
@@ -80,11 +80,11 @@ fn parse_base64(parser: &mut impl Iterator<Item = XmlEventResult>) -> Result<Vec
 fn decode_zlib(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
     use libflate::zlib::Decoder;
     let mut zd =
-        Decoder::new(BufReader::new(&data[..])).map_err(|e| TiledError::IoError(e))?;
+        Decoder::new(BufReader::new(&data[..])).map_err(|e| TiledError::DecompressingError(e))?;
     let mut data = Vec::new();
     match zd.read_to_end(&mut data) {
         Ok(_v) => {}
-        Err(e) => return Err(TiledError::IoError(e)),
+        Err(e) => return Err(TiledError::DecompressingError(e)),
     }
     Ok(data)
 }
@@ -92,11 +92,11 @@ fn decode_zlib(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
 fn decode_gzip(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
     use libflate::gzip::Decoder;
     let mut zd =
-        Decoder::new(BufReader::new(&data[..])).map_err(|e| TiledError::IoError(e))?;
+        Decoder::new(BufReader::new(&data[..])).map_err(|e| TiledError::DecompressingError(e))?;
 
     let mut data = Vec::new();
     zd.read_to_end(&mut data)
-        .map_err(|e| TiledError::IoError(e))?;
+        .map_err(|e| TiledError::DecompressingError(e))?;
     Ok(data)
 }
 
@@ -105,11 +105,11 @@ fn decode_zstd(data: Vec<u8>) -> Result<Vec<u8>, TiledError> {
     use zstd::stream::read::Decoder;
 
     let buff = Cursor::new(&data);
-    let mut zd = Decoder::with_buffer(buff).map_err(|e| TiledError::IoError(e))?;
+    let mut zd = Decoder::with_buffer(buff).map_err(|e| TiledError::DecompressingError(e))?;
 
     let mut data = Vec::new();
     zd.read_to_end(&mut data)
-        .map_err(|e| TiledError::IoError(e))?;
+        .map_err(|e| TiledError::DecompressingError(e))?;
     Ok(data)
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -90,8 +90,7 @@ impl Map {
         path: impl AsRef<Path>,
         cache: &mut impl ResourceCache,
     ) -> Result<Self, TiledError> {
-        let reader = File::open(path.as_ref())
-            .map_err(|_| TiledError::Other(format!("Map file not found: {:?}", path.as_ref())))?;
+        let reader = File::open(path.as_ref()).map_err(|err| TiledError::IoError(err))?;
         Self::parse_reader(reader, path.as_ref(), cache)
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt, fs::File, io::Read, path::Path, rc::Rc, str
 use xml::{attribute::OwnedAttribute, reader::XmlEvent, EventReader};
 
 use crate::{
-    error::{ParseTileError, TiledError},
+    error::TiledError,
     layers::{LayerData, LayerTag},
     properties::{parse_properties, Color, Properties},
     tileset::Tileset,
@@ -256,15 +256,15 @@ pub enum Orientation {
 }
 
 impl FromStr for Orientation {
-    type Err = ParseTileError;
+    type Err = ();
 
-    fn from_str(s: &str) -> Result<Orientation, ParseTileError> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "orthogonal" => Ok(Orientation::Orthogonal),
             "isometric" => Ok(Orientation::Isometric),
             "staggered" => Ok(Orientation::Staggered),
             "hexagonal" => Ok(Orientation::Hexagonal),
-            _ => Err(ParseTileError::OrientationError),
+            _ => Err(()),
         }
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -90,7 +90,10 @@ impl Map {
         path: impl AsRef<Path>,
         cache: &mut impl ResourceCache,
     ) -> Result<Self, TiledError> {
-        let reader = File::open(path.as_ref()).map_err(|err| TiledError::IoError(err))?;
+        let reader = File::open(path.as_ref()).map_err(|err| TiledError::CouldNotOpenFile {
+            path: path.as_ref().to_owned(),
+            err,
+        })?;
         Self::parse_reader(reader, path.as_ref(), cache)
     }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -74,27 +74,39 @@ impl PropertyValue {
         match property_type.as_str() {
             "bool" => match value.parse() {
                 Ok(val) => Ok(PropertyValue::BoolValue(val)),
-                Err(_) => Err(TiledError::InvalidPropertyValue),
+                Err(err) => Err(TiledError::InvalidPropertyValue {
+                    description: err.to_string(),
+                }),
             },
             "float" => match value.parse() {
                 Ok(val) => Ok(PropertyValue::FloatValue(val)),
-                Err(_) => Err(TiledError::InvalidPropertyValue),
+                Err(err) => Err(TiledError::InvalidPropertyValue {
+                    description: err.to_string(),
+                }),
             },
             "int" => match value.parse() {
                 Ok(val) => Ok(PropertyValue::IntValue(val)),
-                Err(_) => Err(TiledError::InvalidPropertyValue),
+                Err(err) => Err(TiledError::InvalidPropertyValue {
+                    description: err.to_string(),
+                }),
             },
             "color" if value.len() > 1 => match u32::from_str_radix(&value[1..], 16) {
                 Ok(color) => Ok(PropertyValue::ColorValue(color)),
-                Err(_) => Err(TiledError::InvalidPropertyValue),
+                Err(err) => Err(TiledError::InvalidPropertyValue {
+                    description: err.to_string(),
+                }),
             },
             "string" => Ok(PropertyValue::StringValue(value)),
             "object" => match value.parse() {
                 Ok(val) => Ok(PropertyValue::ObjectValue(val)),
-                Err(_) => Err(TiledError::InvalidPropertyValue),
+                Err(err) => Err(TiledError::InvalidPropertyValue {
+                    description: err.to_string(),
+                }),
             },
             "file" => Ok(PropertyValue::FileValue(value)),
-            _ => Err(TiledError::UnknownPropertyType{name: property_type}),
+            _ => Err(TiledError::UnknownPropertyType {
+                name: property_type,
+            }),
         }
     }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -74,32 +74,27 @@ impl PropertyValue {
         match property_type.as_str() {
             "bool" => match value.parse() {
                 Ok(val) => Ok(PropertyValue::BoolValue(val)),
-                Err(err) => Err(TiledError::Other(err.to_string())),
+                Err(_) => Err(TiledError::InvalidPropertyValue),
             },
             "float" => match value.parse() {
                 Ok(val) => Ok(PropertyValue::FloatValue(val)),
-                Err(err) => Err(TiledError::Other(err.to_string())),
+                Err(_) => Err(TiledError::InvalidPropertyValue),
             },
             "int" => match value.parse() {
                 Ok(val) => Ok(PropertyValue::IntValue(val)),
-                Err(err) => Err(TiledError::Other(err.to_string())),
+                Err(_) => Err(TiledError::InvalidPropertyValue),
             },
             "color" if value.len() > 1 => match u32::from_str_radix(&value[1..], 16) {
                 Ok(color) => Ok(PropertyValue::ColorValue(color)),
-                Err(_) => Err(TiledError::Other(format!(
-                    "Improperly formatted color property"
-                ))),
+                Err(_) => Err(TiledError::InvalidPropertyValue),
             },
             "string" => Ok(PropertyValue::StringValue(value)),
             "object" => match value.parse() {
                 Ok(val) => Ok(PropertyValue::ObjectValue(val)),
-                Err(err) => Err(TiledError::Other(err.to_string())),
+                Err(_) => Err(TiledError::InvalidPropertyValue),
             },
             "file" => Ok(PropertyValue::FileValue(value)),
-            _ => Err(TiledError::Other(format!(
-                "Unknown property type \"{}\"",
-                property_type
-            ))),
+            _ => Err(TiledError::UnknownPropertyType{name: property_type}),
         }
     }
 }


### PR DESCRIPTION
Closes #142 and closes #124.
Replaces all occurrences of `TiledError::Other` for new error variants and removes `ParseTileError`, among other changes.