### PR TITLE
Adding tileset index

### DIFF
--- a/src/layers/tile/mod.rs
+++ b/src/layers/tile/mod.rs
@@ -107,6 +107,7 @@ impl TileLayerData {
 #[derive(Debug, Clone, PartialEq)]
 pub struct LayerTile<'map> {
     pub tileset: &'map Tileset,
+    pub tileset_index: usize,
     pub id: TileId,
     pub flip_h: bool,
     pub flip_v: bool,
@@ -117,6 +118,7 @@ impl<'map> LayerTile<'map> {
     pub(crate) fn from_data(data: &LayerTileData, map: &'map Map) -> Self {
         Self {
             tileset: &*map.tilesets()[data.tileset_index],
+            tileset_index: data.tileset_index,
             id: data.id,
             flip_h: data.flip_h,
             flip_v: data.flip_v,


### PR DESCRIPTION
I wish to include the tileset index in the LayerTile<'map> facade.
This would assist in making simple rendering code significantly faster.

Say I've loaded my map file and acquire the tilesets:

```rust
let map = Map::parse_xml(...);
let tilesets = map.tilesets();
```

Now, say I load all of the textures of the tilesets.
Assume they're all single-image tilesets.
`textures` is parallel to `tilesets`

```rust
let textures = tilesets.map(|tileset| load_texture(tileset.image.unwrap().source));
```

Now, say my rendering code looks something like this:

```rust
fn render(map: &Map, textures: &[Texture], batch: &mut Batch) {
    let tw = map.tile_width as f32;
    let th = map.tile_height as f32;
    for layer in map.layers() {

        // Assume all layers are tile layers for simplicity
        let layer = match layer.layer_type() {
            LayerDataType::TileLayer(data) => data,
            _ => panic!("Only tile layers supported")
        }
    
        // For all tiles in the layer...
        for x in 0..map.width {
            for y in 0..map.height {
                let layer_tile = layer.get_tile(x, y);
                if let Some(tile) = tile {

                    // Including a `tileset_index` field in LayerTile<'map> would make the rendering code MUCH more efficient in this example.
                    // The current alternative is to make `textures` a HashMap<String, Texture> where String is the tileset name.
                    // For every LayerTile, the Tileset it belongs to would need to be "looked up" by String.
                    //
                    // Admittedly, this could be mitigated by making the graphics structure something like:
                    //     let mut graphics = HashMap<usize, Mesh>::new();
                    // Where the usize is the texture index and the Mesh is just the polyon mesh which uses that texture.
                    //
                    // However, when building such a structure, there would still need to be a hash lookup per tile.
                    // In this scenario, it would hurt the loading time for a game, though not the overall performance.
                    let texture = &textures[layer_tile.tileset_index];

                    // I think I also heard that there was talk of adding UVs to the tileset tiles themselves.
                    // That would definitely make this operation faster as well.
                    let (uv1, uv2) = get_tile_uvs(tile.id, &*map.tilesets[layer_tile.tileset_index]);

                    // Draws tile
                    batch.draw(
                        &texture,
                        uv1, uv2,
                        x as f32, y as f32,
                        tw, th
                    );
                }
            }
        }
    }
}
```

Having a tileset index in the LayerTile<'map> facade type would make rendering the map to a batch much faster.
This unfortunately exposes the tileset's "id" which I am guessing we'd rather not do unless we have to.
I think that rendering code like this is common enough to warrant this sort of change.
Let me know what you all think, though.
There may already be an efficient way of doing this with the current codebase I'm not aware of, and I've just got tunnel vision.