### PR TITLE
Adding tile id to tile

### DIFF
--- a/src/tile.rs
+++ b/src/tile.rs
@@ -15,6 +15,7 @@ pub type TileId = u32;
 
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Tile {
+    pub id: TileId,
     pub image: Option<Image>,
     pub properties: Properties,
     pub collision: Option<ObjectLayerData>,
@@ -28,7 +29,7 @@ impl Tile {
         parser: &mut impl Iterator<Item = XmlEventResult>,
         attrs: Vec<OwnedAttribute>,
         path_relative_to: Option<&Path>,
-    ) -> Result<(TileId, Tile), TiledError> {
+    ) -> Result<Tile, TiledError> {
         let ((tile_type, probability), id) = get_attrs!(
             attrs,
             optionals: [
@@ -63,16 +64,14 @@ impl Tile {
                 Ok(())
             },
         });
-        Ok((
-            id,
-            Tile {
+        Ok(Tile {
+                id,
                 image,
                 properties,
                 collision: objectgroup,
                 animation,
                 tile_type,
                 probability: probability.unwrap_or(1.0),
-            },
-        ))
+        })
     }
 }

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -251,8 +251,8 @@ impl Tileset {
                 Ok(())
             },
             "tile" => |attrs| {
-                let (id, tile) = Tile::new(parser, attrs, prop.path_relative_to.as_ref().and_then(|p| Some(p.as_path())))?;
-                tiles.insert(id, tile);
+                let tile = Tile::new(parser, attrs, prop.path_relative_to.as_ref().and_then(|p| Some(p.as_path())))?;
+                tiles.insert(tile.id, tile);
                 Ok(())
             },
         });


### PR DESCRIPTION
I'd like for the Tile struct to include it's own id.
For my personal project, I need to know the tile id in order to derive it's coordinates in the tileset it belongs to.

IE: 

```rust
let id = tile.id;
tile_x: uint = id % tileset.columns;
tile_y: uint = id / tileset.columns;
// Draw code
```