### PR TITLE
Make malformed tileset attributes error more accurate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix message when a tileset is missing the `tilecount` attribute (#194).
+
 ## [0.10.0]
 As this release changes practically the entire interface of the crate, it is recommended that you
 check out the [examples](https://github.com/mapeditor/rs-tiled/tree/master/examples) instead of the

--- a/src/tileset.rs
+++ b/src/tileset.rs
@@ -171,7 +171,7 @@ impl Tileset {
                 ("tilewidth", width, |v:String| v.parse().ok()),
                 ("tileheight", height, |v:String| v.parse().ok()),
             ],
-            Error::MalformedAttributes("tileset must have a firstgid, name tile width and height with correct types".to_string())
+            Error::MalformedAttributes("tileset must have a firstgid, tilecount, tilewidth, and tileheight with correct types".to_string())
         );
 
         let root_path = map_path.parent().ok_or(Error::PathIsNotFile)?.to_owned();


### PR DESCRIPTION
I got this error message when trying to load a tileset due to my tileset missing the `tilecount` attribute. The error message incorrectly states that `name` is required and omits the fact that `tilecount` is required. As such, I needed to dig through the `rs-tiled` sources to figure out why this error was popping up. This PR makes the error message accurately reflect which attributes are required for a tileset.