### PR TITLE
Fix iterator lifetimes

### DIFF
--- a/src/layers/group.rs
+++ b/src/layers/group.rs
@@ -90,10 +90,14 @@ map_wrapper!(
 
 impl<'map> GroupLayer<'map> {
     /// Returns an iterator over the layers present in this group in display order.
-    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer> {
-        self.layers
+    /// ## Example
+    /// TODO
+    pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer<'map>> + 'map {
+        let map: &'map crate::Map = self.map;
+        self.data
+            .layers
             .iter()
-            .map(move |layer| Layer::new(self.map, layer))
+            .map(move |layer| Layer::new(map, layer))
     }
     /// Gets a specific layer from the group by index.
     pub fn get_layer(&self, index: usize) -> Option<Layer> {

--- a/src/layers/object.rs
+++ b/src/layers/object.rs
@@ -68,10 +68,36 @@ impl<'map> ObjectLayer<'map> {
 
     /// Returns an iterator over the objects present in this layer, in the order they were declared
     /// in in the TMX file.
+    /// 
+    /// ## Example
+    /// ```
+    /// # use tiled::Loader;
+    /// use tiled::Object;
+    ///
+    /// # fn main() {
+    /// # let map = Loader::new()
+    /// #     .load_tmx_map("assets/tiled_group_layers.tmx")
+    /// #     .unwrap();
+    /// # 
+    /// let spawnpoints: Vec<Object> = map
+    ///     .layers()
+    ///     .filter_map(|layer| match layer.layer_type() {
+    ///         tiled::LayerType::ObjectLayer(layer) => Some(layer),
+    ///         _ => None,
+    ///     })
+    ///     .flat_map(|layer| layer.objects())
+    ///     .filter(|object| object.obj_type == "spawn")
+    ///     .collect();
+    ///
+    /// dbg!(spawnpoints);
+    /// # }
+    /// ```
     #[inline]
-    pub fn objects(&self) -> impl ExactSizeIterator<Item = Object> {
-        self.objects
+    pub fn objects(&self) -> impl ExactSizeIterator<Item = Object<'map>> + 'map {
+        let map: &'map crate::Map = self.map;
+        self.data
+            .objects
             .iter()
-            .map(move |object| Object::new(self.map, object))
+            .map(move |object| Object::new(map, object))
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -114,6 +114,31 @@ impl Map {
     }
 
     /// Get an iterator over all the layers in the map in ascending order of their layer index.
+    /// 
+    /// ## Example
+    /// ```
+    /// # use tiled::Loader;
+    /// # 
+    /// # fn main() {
+    /// # struct Renderer;
+    /// # impl Renderer {
+    /// #     fn render(&self, _: tiled::TileLayer) {}
+    /// # }
+    /// # let my_renderer = Renderer;
+    /// # let map = Loader::new()
+    /// #     .load_tmx_map("assets/tiled_group_layers.tmx")
+    /// #     .unwrap();
+    /// #
+    /// let tile_layers = map.layers().filter_map(|layer| match layer.layer_type() {
+    ///     tiled::LayerType::TileLayer(layer) => Some(layer),
+    ///     _ => None,
+    /// });
+    ///
+    /// for layer in tile_layers {
+    ///     my_renderer.render(layer);
+    /// }
+    /// # }
+    /// ```
     #[inline]
     pub fn layers(&self) -> impl ExactSizeIterator<Item = Layer> {
         self.layers.iter().map(move |layer| Layer::new(self, layer))

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -419,3 +419,27 @@ fn test_group_layers() {
         layer_tile_3.properties.get("key")
     );
 }
+
+mod m {
+    use tiled::Loader;
+
+    fn main() {
+        struct Renderer;
+        impl Renderer {
+            fn render(&self, _: tiled::TileLayer) {}
+        }
+        let my_renderer = Renderer;
+        let map = Loader::new()
+            .load_tmx_map("assets/tiled_group_layers.tmx")
+            .unwrap();
+
+        let tile_layers = map.layers().filter_map(|layer| match layer.layer_type() {
+            tiled::LayerType::TileLayer(layer) => Some(layer),
+            _ => None,
+        });
+
+        for layer in tile_layers {
+            my_renderer.render(layer);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes some small lifetime issues with moderately big implications. Currently, code like this fails:
```rs
use tiled::Object;

let spawnpoints: Vec<Object> = map
    .layers()
    .filter_map(|layer| match layer.layer_type() {
        tiled::LayerType::ObjectLayer(layer) => Some(layer),
        _ => None,
    })
    .flat_map(|layer| layer.objects())
    .filter(|object| object.obj_type == "spawn")
    .collect();

dbg!(spawnpoints);
```
The compiler complains with:
```rs
error[E0515]: cannot return reference to function parameter `layer`
  --> src/layers/object.rs:88:23
   |
17 |     .flat_map(|layer| layer.objects())
   |                       ^^^^^^^^^^^^^^^ returns a reference to data owned by the current function

error: aborting due to previous error
```
This is due to the declaration of `impl ExactSizeIterator` functions:
```rs
pub fn objects(&self) -> impl ExactSizeIterator<Item = Object>
```
Which, expanded, look like this:
```rs
pub fn objects<'s>(&'s self) -> impl ExactSizeIterator<Item = Object<'s>> + 's
```
Which limit the lifetime of the iterator and its items to the mapwrapper object. This is not required because the mapwrapper object is just a reference tuple, and so these functions should be like this:
```rs
pub fn objects(&self) -> impl ExactSizeIterator<Item = Object<'map>> + 'map
```
This PR fixes these issues and enforces the fix with some doctests.