### PR TITLE
Enforce ResourceReader errors to be Send + Sync

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
         /// The path to the file that was unable to be opened.
         path: PathBuf,
         /// The error that occured when trying to open the file.
-        err: Box<dyn std::error::Error>,
+        err: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
     /// There was an invalid tile in the map parsed.
     InvalidTileFound,

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -14,7 +14,7 @@ pub trait ResourceReader {
     type Resource: Read;
     /// The type that is returned if [`read_from()`](Self::read_from()) fails. For example, for
     /// [`FilesystemResourceReader`], this is defined as [`std::io::Error`].
-    type Error: std::error::Error + 'static;
+    type Error: std::error::Error + Send + Sync + 'static;
 
     /// Try to return a reader object from a path into the resources filesystem.
     fn read_from(&mut self, path: &Path) -> std::result::Result<Self::Resource, Self::Error>;


### PR DESCRIPTION
This makes ResourceReader errors closer to `anyhow`'s, which allows Tiled errors to be converted into theirs.