### PR TITLE
Add basic chunk utilities to infinite layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.2]
 ### Added
+- Map-wrapped chunks: `ChunkWrapper`.
+- Ability to access infinite tile layer chunks via `InfiniteTileLayerData::chunks` & 
+`InfiniteTileLayerData::chunk_data`, as well as chunk data via `Chunk::get_tile_data` &
+`ChunkWrapper::get_tile`.
 - `TileLayer::width` & `TileLayer::height` for ergonomic access of width/height.
 - `FiniteTileLayerData::get_tile_data`, `InfiniteTileLayerData::get_tile_data`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.2]
 ### Added
 - Map-wrapped chunks: `ChunkWrapper`.
-- Ability to access infinite tile layer chunks via `InfiniteTileLayerData::chunks` & 
-`InfiniteTileLayerData::chunk_data`, as well as chunk data via `Chunk::get_tile_data` &
+- Ability to access infinite tile layer chunks via `InfiniteTileLayer::chunks`, 
+`InfiniteTileLayerData::chunk_data`, `InfiniteTileLayerData::get_chunk_data` &
+`InfiniteTileLayer::get_chunk`, as well as chunk data via `Chunk::get_tile_data` &
 `ChunkWrapper::get_tile`.
 - `TileLayer::width` & `TileLayer::height` for ergonomic access of width/height.
 - `FiniteTileLayerData::get_tile_data`, `InfiniteTileLayerData::get_tile_data`.

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -76,6 +76,18 @@ impl InfiniteTileLayerData {
             })
             .flatten()
     }
+
+    /// Returns an iterator over only the data part of the chunks of this tile layer.
+    ///
+    /// In 99.99% of cases you'll want to use [`Self::chunks()`] instead; Using this method is only
+    /// needed if you *only* require the tile data of the chunks (and no other utilities provided by
+    /// the map-wrapped [`LayerTile`]), and you are in dire need for that extra bit of performance.
+    ///
+    /// This iterator doesn't have any particular order set.
+    #[inline]
+    pub fn chunk_data(&self) -> impl ExactSizeIterator<Item = ((i32, i32), &Chunk)> {
+        self.chunks.iter().map(|(pos, chunk)| (*pos, chunk))
+    }
 }
 
 fn tile_to_chunk_pos(x: i32, y: i32) -> (i32, i32) {
@@ -85,27 +97,63 @@ fn tile_to_chunk_pos(x: i32, y: i32) -> (i32, i32) {
     )
 }
 
-/// Part of an infinite tile layer.
+/// Part of an infinite tile layer's data.
+///
+/// Has only the tile data contained within and not a reference to the map it is part of. It is for
+/// this reason that this type should actually be called `ChunkData`, and so this will change in
+/// the next breaking release. In 99.99% of cases you'll actually want to use [`ChunkWrapper`].
+// TODO: Rename to ChunkData
 #[derive(Debug, PartialEq, Clone)]
 pub struct Chunk {
     tiles: Box<[Option<LayerTileData>; Self::TILE_COUNT]>,
 }
 
 impl Chunk {
-    /// Internal infinite layer chunk width. Do not rely on this value as it might change between
-    /// versions.
+    /// Infinite layer chunk width. This constant might change between versions, not counting as a
+    /// breaking change.
     pub const WIDTH: u32 = 16;
-    /// Internal infinite layer chunk height. Do not rely on this value as it might change between
-    /// versions.
+    /// Infinite layer chunk height. This constant might change between versions, not counting as a
+    /// breaking change.
     pub const HEIGHT: u32 = 16;
-    /// Internal infinite layer chunk tile count. Do not rely on this value as it might change
-    /// between versions.
+    /// Infinite layer chunk tile count. This constant might change between versions, not counting
+    /// as a breaking change.
     pub const TILE_COUNT: usize = Self::WIDTH as usize * Self::HEIGHT as usize;
 
     pub(crate) fn new() -> Self {
         Self {
             tiles: Box::new([None; Self::TILE_COUNT]),
         }
+    }
+
+    /// Obtains the tile data present at the position given relative to the chunk's top-left-most tile.
+    ///
+    /// If the position given is invalid or the position is empty, this function will return [`None`].
+    ///
+    /// If you want to get a [`LayerTile`](`crate::LayerTile`) instead, use [`ChunkWrapper::get_tile()`].
+    pub fn get_tile_data(&self, x: i32, y: i32) -> Option<&LayerTileData> {
+        if x < Self::WIDTH as i32 && y < Self::HEIGHT as i32 && x >= 0 && y >= 0 {
+            self.tiles[x as usize + y as usize * Self::WIDTH as usize].as_ref()
+        } else {
+            None
+        }
+    }
+}
+
+// TODO: Rename to Chunk
+map_wrapper!(
+    #[doc = "Part of an [`InfiniteTileLayer`]."]
+    #[doc = "This is the only map-wrapped type that has a `Wrapper` suffix. This will change in a later version."]
+    ChunkWrapper => Chunk
+);
+
+impl<'map> ChunkWrapper<'map> {
+    /// Obtains the tile present at the position given relative to the chunk's top-left-most tile.
+    ///
+    /// If the position given is invalid or the position is empty, this function will return [`None`].
+    pub fn get_tile(&self, x: i32, y: i32) -> Option<LayerTile<'map>> {
+        self.data
+            .get_tile_data(x, y)
+            .map(|data| LayerTile::new(self.map(), data))
     }
 }
 
@@ -166,5 +214,52 @@ impl<'map> InfiniteTileLayer<'map> {
         self.data
             .get_tile_data(x, y)
             .map(|data| LayerTile::new(self.map, data))
+    }
+
+    /// Returns an iterator over different parts of this map called [`Chunk`]s.
+    ///
+    /// These **may not** correspond with the chunks in the TMX file, as the chunk size is
+    /// implementation defined (Check [`Chunk::WIDTH`], [`Chunk::HEIGHT`]).
+    ///
+    /// The iterator item contains the position of the chunk in chunk coordinates along with a
+    /// reference to the actual chunk at that position.
+    ///
+    /// This iterator doesn't have any particular order set.
+    ///
+    /// ## Example
+    /// ```
+    /// # use tiled::{Loader, LayerType, TileLayer};
+    /// use tiled::Chunk;
+    ///
+    /// # let map = Loader::new()
+    /// #     .load_tmx_map("assets/tiled_base64_zlib_infinite.tmx")
+    /// #     .unwrap();
+    /// # if let LayerType::TileLayer(TileLayer::Infinite(infinite_layer)) =
+    /// #     &map.get_layer(0).unwrap().layer_type()
+    /// # {
+    /// for (chunk_pos, chunk) in infinite_layer.chunks() {
+    ///     for x in 0..Chunk::WIDTH as i32 {
+    ///         for y in 0..Chunk::HEIGHT as i32 {
+    ///             if let Some(tile) = chunk.get_tile(x, y) {
+    ///                 let tile_pos = (
+    ///                     chunk_pos.0 * Chunk::WIDTH as i32 + x,
+    ///                     chunk_pos.1 * Chunk::HEIGHT as i32 + y,
+    ///                 );
+    ///                 println!("At ({}, {}): {:?}", tile_pos.0, tile_pos.1, tile);
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// # } else {
+    /// #     panic!("It is wrongly recognised as a finite map");
+    /// # }
+    /// ```
+    #[inline]
+    pub fn chunks(&self) -> impl ExactSizeIterator<Item = ((i32, i32), ChunkWrapper<'map>)> + 'map {
+        let map: &'map crate::Map = self.map;
+        self.data
+            .chunks
+            .iter()
+            .map(move |(pos, chunk)| (*pos, ChunkWrapper::new(map, chunk)))
     }
 }

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -102,7 +102,7 @@ fn tile_to_chunk_pos(x: i32, y: i32) -> (i32, i32) {
 /// Has only the tile data contained within and not a reference to the map it is part of. It is for
 /// this reason that this type should actually be called `ChunkData`, and so this will change in
 /// the next breaking release. In 99.99% of cases you'll actually want to use [`ChunkWrapper`].
-// TODO: Rename to ChunkData
+// TODO(0.11.0): Rename to ChunkData
 #[derive(Debug, PartialEq, Clone)]
 pub struct Chunk {
     tiles: Box<[Option<LayerTileData>; Self::TILE_COUNT]>,
@@ -139,7 +139,7 @@ impl Chunk {
     }
 }
 
-// TODO: Rename to Chunk
+// TODO(0.11.0): Rename to Chunk
 map_wrapper!(
     #[doc = "Part of an [`InfiniteTileLayer`]."]
     #[doc = "This is the only map-wrapped type that has a `Wrapper` suffix. This will change in a later version."]

--- a/src/layers/tile/infinite.rs
+++ b/src/layers/tile/infinite.rs
@@ -83,7 +83,7 @@ impl InfiniteTileLayerData {
     /// needed if you *only* require the tile data of the chunks (and no other utilities provided by
     /// the map-wrapped [`LayerTile`]), and you are in dire need for that extra bit of performance.
     ///
-    /// This iterator doesn't have any particular order set.
+    /// This iterator doesn't have any particular order.
     #[inline]
     pub fn chunk_data(&self) -> impl ExactSizeIterator<Item = ((i32, i32), &Chunk)> {
         self.chunks.iter().map(|(pos, chunk)| (*pos, chunk))
@@ -219,12 +219,12 @@ impl<'map> InfiniteTileLayer<'map> {
     /// Returns an iterator over different parts of this map called [`Chunk`]s.
     ///
     /// These **may not** correspond with the chunks in the TMX file, as the chunk size is
-    /// implementation defined (Check [`Chunk::WIDTH`], [`Chunk::HEIGHT`]).
+    /// implementation defined (see [`Chunk::WIDTH`], [`Chunk::HEIGHT`]).
     ///
     /// The iterator item contains the position of the chunk in chunk coordinates along with a
     /// reference to the actual chunk at that position.
     ///
-    /// This iterator doesn't have any particular order set.
+    /// This iterator doesn't have any particular order.
     ///
     /// ## Example
     /// ```

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -117,7 +117,7 @@ fn test_just_tileset() {
 }
 
 #[test]
-fn test_infinite_tileset() {
+fn test_infinite_map() {
     let r = Loader::new()
         .load_tmx_map("assets/tiled_base64_zlib_infinite.tmx")
         .unwrap();


### PR DESCRIPTION
As requested by @ShikuWorld & @adambiltcliffe in #167. I'd appreciate if you could review these changes as well, to see if they suit your needs.

Adds map-wrapped chunks (`ChunkWrapper`) and the ability to access infinite tile layer chunks via `InfiniteTileLayerData::chunks` & `InfiniteTileLayerData::chunk_data`, as well as chunk data via `Chunk::get_tile_data` & `ChunkWrapper::get_tile`.